### PR TITLE
sdk upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ https://github.com/growingio/AndroidDemo/blob/shopping/createEvents/README.md
 [AppLink 帮助文档](https://docs.growingio.com/docs/configuration/project-configuration#pei-zhi-app-linksandroid)  
 [自定义参数获取文档](https://docs.growingio.com/docs/sdk-integration/android-sdk/android-sdk#deep-link-hui-tiao-can-shu-huo-qu) 
 
+### 4.最新APK
+为了获取最新的版本，请到[release页面](https://github.com/growingio/AndroidDemo/releases)下载最新的apk而不是扫码下载。

--- a/app/src/main/java/com/growingio/giodemo/GIOApplication.kt
+++ b/app/src/main/java/com/growingio/giodemo/GIOApplication.kt
@@ -41,11 +41,11 @@ class GIOApplication : MultiDexApplication() {
                 .setChannel(BuildConfig.CHANNEL)
                 .setUploadExceptionEnable(false)
 //              ------Demo 环境， 请勿修改------
-                .setDataHost("https://demo1.growingio.com")
-                .setReportHost("https://demo1gta.growingio.com")
-                .setTrackerHost("https://apifwd.growingio.com")
-                .setGtaHost("https://demo1gta.growingio.com")
-                .setWsHost("wss://demo1gta.growingio.com")
+//                .setDataHost("https://demo1.growingio.com")
+//                .setReportHost("https://demo1gta.growingio.com")
+//                .setTrackerHost("https://apifwd.growingio.com")
+//                .setGtaHost("https://demo1gta.growingio.com")
+//                .setWsHost("wss://demo1gta.growingio.com")
                 .enablePushTrack()
 //              ------Demo 环境， 请勿修改------
 //              - 广告监测短链： https://gio.ren/PQ2r6aaidoMo ，自定义参数：{"param":"GIO 马克杯","jumpTo":"productDetail"}

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,8 @@ org.gradle.jvmargs=-Xmx1536m
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-GROWINGIO_SDK_VERSION=autotrack-2.8.20
-GTouch_SDK_VERSION=1.4.4
+GROWINGIO_SDK_VERSION=autotrack-2.8.25
+GTouch_SDK_VERSION=1.4.6
 
 # vivo 安装应用显示包解析错误解决
 android.injected.testOnly = false


### PR DESCRIPTION
1. gtouch -> 1.4.6
2. tracker -> 2.8.25
3. 注释掉demo地址，防止官网正式版无法使用